### PR TITLE
chore(billing): remove billing from prod nav (for now)

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -11,39 +11,6 @@
                 "href": "/accounts/{{accountNumber}}",
                 "key": "accountOverview",
                 "linkText": "Overview"
-            },
-            {
-                "linkText": "Billing",
-                "key": "accountBilling",
-                "visibility": "('unified-preprod' | rxEnvironmentMatch) || ('local' | rxEnvironmentMatch)",
-                "childVisibility": ["rxPathParams", { "param": "accountNumber" }],
-                "children": [
-                    {
-                        "href": "/billing/overview/{{accountNumber}}",
-                        "key": "accountBillingOverview",
-                        "linkText": "Overview"
-                    }, {
-                        "href": "/billing/transactions/{{accountNumber}}",
-                        "key": "accountBillingTransactions",
-                        "linkText": "Transactions"
-                    }, {
-                        "href": "/billing/usage/{{accountNumber}}",
-                        "key": "accountBillingCurrentUsage",
-                        "linkText": "Current Usage"
-                    }, {
-                        "href": "/billing/payment/{{accountNumber}}/options",
-                        "key": "accountBillingPaymentOptions",
-                        "linkText": "Payment Options"
-                    }, {
-                        "href": "/billing/purchase-orders/{{accountNumber}}",
-                        "key": "accountBillingPurchaseOrders",
-                        "linkText": "Purchase Orders"
-                    }, {
-                        "href": "/billing/preferences/{{accountNumber}}",
-                        "key": "accountBillingPreferences",
-                        "linkText": "Preferences"
-                    }
-                ]
             }, {
                 "linkText": "Cloud",
                 "key": "cloud",
@@ -82,12 +49,6 @@
                 "key": "accountSupport"
             }
         ]
-    },
-    {
-        "linkText": "Billing",
-        "key": "billing",
-        "directive": "rx-billing-search",
-        "visibility": "('unified-preprod' | rxEnvironmentMatch) || ('local' | rxEnvironmentMatch)"
     },
     {
         "href": "/support",


### PR DESCRIPTION
Instead of using `rxEnvironmentMatch` to hide the billing logic, we're going to rely on the three different branches inside of encore-ui-nav. There will be a couple of other PRs opened to remove the `visibility` param in staging and pre-prod.

/cc @velveteer 