### PR TITLE
chore(billing): Remove dropdown style and add href

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -87,11 +87,11 @@
         ]
     },
     {
+        "href": "/billing/search",
         "linkText": "Billing Search (Alpha)",
         "key": "billing",
         "directive": "rx-billing-search",
         "visibility": "('unified-preprod' | rxEnvironmentMatch) || ('local' | rxEnvironmentMatch)",
-        "children": [{}],
         "childVisibility": false
     },
     {

--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -91,7 +91,6 @@
         "linkText": "Billing Search (Alpha)",
         "key": "billing",
         "directive": "rx-billing-search",
-        "visibility": "('unified-preprod' | rxEnvironmentMatch) || ('local' | rxEnvironmentMatch)",
         "childVisibility": false
     },
     {


### PR DESCRIPTION
`/billing/search` is a valid Angular route, but it will display an empty page until results are populated. The usage of this route is to prevent the expansion of the Billing Search nav item when inside of any `/billing` routes.