### PR TITLE
feat(VirtAdmin): Added virt children to nav

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -118,7 +118,22 @@
         "href": "/virt",
         "linkText": "Virtualization Admin",
         "key": "virt",
-        "directive": "rx-virt-search"
+        "directive": "rx-virt-search",
+        "children": [
+                {
+                    "href": "/virt/{{type}}vcenters",
+                    "linkText": "vCenters"
+                }, {
+                    "href": "/virt/{{type}}hypervisor-clusters",
+                    "linkText": "Hypervisor Clusters"
+                }, {
+                    "href": "/virt/{{type}}hypervisors",
+                    "linkText": "Hypervisors"
+                }, {
+                    "href": "/virt/{{type}}vms",
+                    "linkText": "VMs"
+                }
+            ]
     }, {
         "linkText": "Support Automation",
         "key": "supportAutomation",


### PR DESCRIPTION
vCenter UI's nav children previously were manually injected into the nav in the app. With vCenter UI being updated to Encore 1.6, vCenter will now make use of the CDN hosted, json nav file. As such, the child nav elements will need to be added to the json file.

https://jira.rax.io/browse/EOD-398