### PR TITLE
Put back "Add Load Balancer Service to Support Automation.""

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -134,6 +134,11 @@
                 "key": "esxRekick",
                 "visibility": "('unified-preprod' | rxEnvironmentMatch) || ('local' | rxEnvironmentMatch)",
                 "directive": "esx-rekick-search"
+            }, {
+                "href": "/dcx/load-balancer-service",
+                "linkText": "Load Balancer Service",
+                "key": "lbs",
+                "directive": "lbs-search"
             }
         ]
     }]


### PR DESCRIPTION
Reverts rackerlabs/encore-ui-nav#67

The original deploy of this code failed to deploy. We had to revert and redeploy to get back to the old state. Now we're reverting the revert to get back to where we're *supposed* to be.