### PR TITLE
feat(infrastructure): add DCX nav item with infrastructure child.

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -71,6 +71,34 @@
         "childVisibility": false
     },
     {
+        "linkText": "DCX",
+        "key": "dcx",
+        "children": [
+            {
+                "href": "/dcx/infrastructure-encore",
+                "linkText": "Infrastructure Manager",
+                "key": "infrastructure",
+                "children": [
+                    {
+                        "href": "/dcx/infrastructure-encore/cells",
+                        "linkText": "Cells",
+                        "key": "cells"
+                    },
+                    {
+                        "href": "/dcx/infrastructure-encore/containers",
+                        "linkText": "Containers",
+                        "key": "containers"
+                    },
+                    {
+                        "href": "/dcx/infrastructure-encore/deployments",
+                        "linkText": "Deployments",
+                        "key": "deployments"
+                    }
+                ]
+            }
+        ]
+    },
+    {
         "href": "/support",
         "linkText": "Support Service",
         "key": "supportService",


### PR DESCRIPTION
This PR adds a new root-level item to the nav, DCX.  I do not feel that this application fits into any of the existing items; it is used by dc techs to automate hardware deployments in the datacenters.  I'm flexible on the name - perhaps there are other related apps coming down the pipe that I don't know about.  I do know that my team has vague plans to put another app called Unified Control Panel, which would fall in the same bucket, in Encore.

![screen shot 2015-03-30 at 1 45 47 pm](https://cloud.githubusercontent.com/assets/5414922/6904367/f45417de-d6e5-11e4-9dfc-b8f032d1115e.png)
