### PR TITLE
feat(accounts): Add Link to ticketing

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -57,6 +57,10 @@
                 "linkText": "Reports",
                 "key": "accountReports"
             }, {
+                "href": "/ticketing/account/{{accountNumber}}",
+                "linkText": "Tickets",
+                "key": "accountTickets"
+            }, {
                 "href": "/support/accounts/{{accountNumber}}",
                 "linkText": "Support Details",
                 "key": "accountSupport"


### PR DESCRIPTION
![screen shot 2015-05-15 at 1 20 02 am](https://cloud.githubusercontent.com/assets/1437154/7647819/9c3bcdb0-faa0-11e4-8d46-24fdeba33c1a.png)

@quesi82 @solim8r @lfielder @glynnis @ElementE 

While in Rome... this is likely the more ideal place to have the ticketing link as it is global to all account applications (Account, Billing, Cloud, Support) and be accessible from any of these. 

- [x] @quesi82 
- [x] @kobowley 