### PR TITLE
fix(navbar) ECUI-25: logging route fix (preprod)

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -79,7 +79,7 @@
                         "linkText": "Audit History",
                         "key": "accountReports"
                     },{
-                        "href": "/logging/{{accountNumber}}/",
+                        "href": "/logging/{{accountNumber}}/{{user}}",
                         "linkText": "Encore Activity Log",
                         "key": "encoreLogs"
                     }


### PR DESCRIPTION
While making the logging landing page we notice that rx-app uses the username so we added it on to the route here.

jira: https://jira.rax.io/browse/ECUI-25