### PR TITLE
fix(navbar) ECUI-25 added a url parameter to wrong url

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -75,11 +75,11 @@
                 "key": "logReports",
                 "children": [
                     {
-                        "href": "/accounts/reports/{{accountNumber}}/{{user}}",
+                        "href": "/accounts/reports/{{accountNumber}}",
                         "linkText": "Audit History",
                         "key": "accountReports"
                     },{
-                        "href": "/logging/{{accountNumber}}/",
+                        "href": "/logging/{{accountNumber}}/{{user}}",
                         "linkText": "Encore Activity Log",
                         "key": "encoreLogs"
                     }


### PR DESCRIPTION
@halkon Sorry about this. I accidently added the `{{user}}` to "audit history" instead of "encore activity log"