### PR TITLE
Add Cloud Sites to nav

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -53,6 +53,9 @@
                         "href": "/cloud/{{accountNumber}}/{{user}}/images",
                         "linkText": "Cloud Images"
                     }, {
+                        "href": "/cloud/sites/{{accountNumber}}/{{user}}",
+                        "linkText": "Cloud Sites"
+                    }, {
                         "href": "/cloud/{{accountNumber}}/{{user}}/databases/instances",
                         "linkText": "Databases"
                     }, {


### PR DESCRIPTION
This PR adds Cloud Sites to the nav.

The project is already deployed in production, e.g. https://encore.rackspace.com/cloud/sites/708237/cloudqe2