### PR TITLE
fix(torq): put back kick/config

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -145,6 +145,11 @@
                         "key": "releaseNotes"
                     },
                     {
+                        "href": "/dcx/torq/kick/config",
+                        "linkText": "FireKick Config",
+                        "key": "firekickconfig"
+                    },
+                    {
                         "href": "/dcx/torq/kick/templates",
                         "linkText": "FireKick Templates",
                         "key": "templates"


### PR DESCRIPTION
Provide a link to get to the FireKick configuration generator (previously provided by the parent nav item).