### PR TITLE
feat(Billing): update nav schema for new billing url format

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -14,7 +14,7 @@
             },
             {
                 "linkText": "Billing",
-                "href": "/billing/{{accountNumber}}",
+                "href": "/billing/{{accountType}}/{{accountNumber}}",
                 "key": "accountBilling"
             }, {
                 "linkText": "Cloud Products",


### PR DESCRIPTION
Billing will now support including the account type in the URL. In order to keep the nav from resetting, the nav json must be updated to reflect this.